### PR TITLE
MA-2 Added multiple effect action: work in progress

### DIFF
--- a/src/Battle/Unit/Effect/Effect.php
+++ b/src/Battle/Unit/Effect/Effect.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Battle\Unit\Effect;
 
 use Battle\Action\ActionCollection;
-use Battle\Action\ActionException;
+use Battle\Action\ActionFactory;
+use Battle\Action\ActionInterface;
 use Battle\Action\BuffAction;
 use Battle\Unit\UnitInterface;
+use Exception;
 
 class Effect implements EffectInterface
 {
@@ -32,27 +34,42 @@ class Effect implements EffectInterface
     private $duration;
 
     /**
-     * @var ActionCollection
+     * Массив данных по Actions, на основе которого будет создаваться ActionCollection для применения к юниту при
+     * применении эффекта
+     *
+     * @var array
      */
     private $onApplyActions;
 
     /**
-     * @var ActionCollection
+     * Массив данных по Actions, на основе которого будет создаваться ActionCollection для применения к юниту при
+     * начале нового раунда (при ходе юнита в новом раунде)
+     *
+     * @var array
      */
     private $onNextRoundActions;
 
     /**
-     * @var ActionCollection
+     * Массив данных по Actions, на основе которого будет создаваться ActionCollection для применения к юниту при
+     * истечении эффекта
+     *
+     * @var array
      */
     private $onDisableActions;
+
+    /**
+     * @var ActionFactory
+     */
+    private $actionFactory;
 
     public function __construct(
         string $name,
         string $icon,
         int $duration,
-        ActionCollection $onApplyActions,
-        ActionCollection $onNextRoundActions,
-        ActionCollection $onDisableActions
+        array $onApplyActions,
+        array $onNextRoundActions,
+        array $onDisableActions,
+        ActionFactory $actionFactory = null
     )
     {
         $this->name = $name;
@@ -62,6 +79,7 @@ class Effect implements EffectInterface
         $this->onApplyActions = $onApplyActions;
         $this->onNextRoundActions = $onNextRoundActions;
         $this->onDisableActions = $onDisableActions;
+        $this->actionFactory = $actionFactory ?? new ActionFactory();
     }
 
     /**
@@ -98,27 +116,29 @@ class Effect implements EffectInterface
 
     /**
      * @return ActionCollection
+     * @throws Exception
      */
     public function getOnApplyActions(): ActionCollection
     {
-        return $this->onApplyActions;
+        return $this->createActionCollection($this->onApplyActions);
     }
 
     /**
      * @return ActionCollection
+     * @throws Exception
      */
     public function getOnNextRoundActions(): ActionCollection
     {
-        return $this->onNextRoundActions;
+        return $this->createActionCollection($this->onNextRoundActions);
     }
 
     /**
      * @return ActionCollection
-     * @throws ActionException
+     * @throws Exception
      */
     public function getOnDisableActions(): ActionCollection
     {
-        $collection = $this->onDisableActions;
+        $collection = $this->createActionCollection($this->onDisableActions);
 
         // Также, к коллекции событий необходимо добавить revertAction от бафов, примененных сразу
         foreach ($this->onApplyActions as $applyAction) {
@@ -160,5 +180,35 @@ class Effect implements EffectInterface
         foreach ($this->onDisableActions as $onDisableAction) {
             $onDisableAction->changeActionUnit($unit);
         }
+    }
+
+    /**
+     * @param array $data
+     * @return ActionCollection
+     * @throws Exception
+     */
+    private function createActionCollection(array $data): ActionCollection
+    {
+        $collection = new ActionCollection();
+
+        foreach ($data as $datum) {
+            $collection->add($this->createAction($datum));
+        }
+
+        return $collection;
+    }
+
+    /**
+     * @param $data
+     * @return ActionInterface
+     * @throws Exception
+     */
+    private function createAction($data): ActionInterface
+    {
+        if (!is_array($data)) {
+            throw new EffectException(EffectException::INVALID_ACTION_DATA);
+        }
+
+        return $this->actionFactory->create($data);
     }
 }

--- a/src/Battle/Unit/Effect/EffectFactory.php
+++ b/src/Battle/Unit/Effect/EffectFactory.php
@@ -45,17 +45,19 @@ class EffectFactory
             throw new EffectException(EffectException::ZERO_ACTION);
         }
 
-        $onApplyActionCollection = $this->createActionCollection($onApplyActionsData);
-        $onNextRoundActions = $this->createActionCollection($onNextRoundActionsData);
-        $onDisableActions = $this->createActionCollection($onDisableActionsData);
+        // Цель создания коллекций - сразу проверить, что в данных нет ошибки
+        // В сам эффект будут переданы массивы данных
+        $this->createActionCollection($onApplyActionsData);
+        $this->createActionCollection($onNextRoundActionsData);
+        $this->createActionCollection($onDisableActionsData);
 
         return new Effect(
             $name,
             $icon,
             $duration,
-            $onApplyActionCollection,
-            $onNextRoundActions,
-            $onDisableActions
+            $onApplyActionsData,
+            $onNextRoundActionsData,
+            $onDisableActionsData
         );
     }
 

--- a/tests/Battle/Action/EffectActionTest.php
+++ b/tests/Battle/Action/EffectActionTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Battle\Action;
 
-use Battle\Action\ActionCollection;
 use Battle\Action\ActionException;
 use Battle\Action\ActionFactory;
 use Battle\Action\ActionInterface;
@@ -205,14 +204,19 @@ class EffectActionTest extends AbstractUnitTest
         $icon = 'icon.png';
         $duration = 10;
 
-        $action = $this->getReserveForcesAction($unit, $enemyCommand, $command, EffectAction::TARGET_SELF);
+        $actionsData = $this->getReserveForcesActionData($unit, $enemyCommand, $command, EffectAction::TARGET_SELF);
 
-        $actionCollection = new ActionCollection();
-        $actionCollection->add($action);
+        $effect = new Effect($name, $icon, $duration, [], $actionsData, []);
 
-        $effect = new Effect($name, $icon, $duration, new ActionCollection(), $actionCollection, new ActionCollection());
-
-        $effectAction = new EffectAction($unit, $enemyCommand, $command, EffectAction::TARGET_SELF, $name, $icon, $effect);
+        $effectAction = new EffectAction(
+            $unit,
+            $enemyCommand,
+            $command,
+            EffectAction::TARGET_SELF,
+            $name,
+            $icon,
+            $effect
+        );
 
         self::assertEquals(EffectAction::DEFAULT_ANIMATION_METHOD, $effectAction->getAnimationMethod());
         self::assertEquals(EffectAction::DEFAULT_MESSAGE_METHOD, $effectAction->getMessageMethod());
@@ -237,12 +241,9 @@ class EffectActionTest extends AbstractUnitTest
         $animationMethod = 'custom_animate_method';
         $messageMethod = 'custom_message_method';
 
-        $action = $this->getReserveForcesAction($unit, $enemyCommand, $command, EffectAction::TARGET_SELF);
+        $actionsData = $this->getReserveForcesActionData($unit, $enemyCommand, $command, EffectAction::TARGET_SELF);
 
-        $actionCollection = new ActionCollection();
-        $actionCollection->add($action);
-
-        $effect = new Effect($name, $icon, $duration, new ActionCollection(), $actionCollection, new ActionCollection());
+        $effect = new Effect($name, $icon, $duration, [], $actionsData, []);
 
         $effectAction = new EffectAction(
             $unit,
@@ -308,6 +309,53 @@ class EffectActionTest extends AbstractUnitTest
         ];
 
         return $actionFactory->create($data);
+    }
+
+    /**
+     * Возвращает массив данных, по аналогу с getReserveForcesAction
+     *
+     * @param UnitInterface $unit
+     * @param CommandInterface $enemyCommand
+     * @param CommandInterface $command
+     * @param int $typeTarget
+     * @return array[]
+     */
+    private function getReserveForcesActionData(
+        UnitInterface $unit,
+        CommandInterface $enemyCommand,
+        CommandInterface $command,
+        int $typeTarget
+    ): array
+    {
+        return [
+            [
+                'type'           => ActionInterface::EFFECT,
+                'action_unit'    => $unit,
+                'enemy_command'  => $enemyCommand,
+                'allies_command' => $command,
+                'type_target'    => $typeTarget,
+                'name'           => 'use Reserve Forces',
+                'effect'         => [
+                    'name'                  => 'Effect#123',
+                    'icon'                  => 'icon.png',
+                    'duration'              => 8,
+                    'on_apply_actions'      => [
+                        [
+                            'type'           => ActionInterface::BUFF,
+                            'action_unit'    => $unit,
+                            'enemy_command'  => $enemyCommand,
+                            'allies_command' => $command,
+                            'type_target'    => ActionInterface::TARGET_SELF,
+                            'name'           => 'use Reserve Forces',
+                            'modify_method'  => 'multiplierMaxLife',
+                            'power'          => 130,
+                        ],
+                    ],
+                    'on_next_round_actions' => [],
+                    'on_disable_actions'    => [],
+                ],
+            ]
+        ];
     }
 
     /**

--- a/tests/Battle/Unit/Effect/EffectCollectionTest.php
+++ b/tests/Battle/Unit/Effect/EffectCollectionTest.php
@@ -6,12 +6,15 @@ namespace Tests\Battle\Unit\Effect;
 
 use Battle\Action\ActionCollection;
 use Battle\Action\ActionException;
+use Battle\Action\ActionInterface;
 use Battle\Action\HealAction;
 use Battle\Command\CommandException;
 use Battle\Command\CommandFactory;
+use Battle\Command\CommandInterface;
 use Battle\Unit\Effect\Effect;
 use Battle\Unit\Effect\EffectCollection;
 use Battle\Unit\UnitException;
+use Battle\Unit\UnitInterface;
 use Tests\AbstractUnitTest;
 use Tests\Battle\Factory\UnitFactory;
 use Tests\Battle\Factory\UnitFactoryException;
@@ -30,18 +33,18 @@ class EffectCollectionTest extends AbstractUnitTest
             'Effect#1',
             'icon',
             10,
-            new ActionCollection(),
-            new ActionCollection(),
-            new ActionCollection()
+            [],
+            [],
+            []
         ));
 
         $collection->add(new Effect(
             'Effect#2',
             'icon',
             10,
-            new ActionCollection(),
-            new ActionCollection(),
-            new ActionCollection()
+            [],
+            [],
+            []
         ));
 
         self::assertCount(2, $collection);
@@ -67,18 +70,18 @@ class EffectCollectionTest extends AbstractUnitTest
             'Effect#1',
             'icon',
             10,
-            new ActionCollection(),
-            new ActionCollection(),
-            new ActionCollection()
+            [],
+            [],
+            []
         );
 
         $effect2 = new Effect(
             'Effect#2',
             'icon',
             10,
-            new ActionCollection(),
-            new ActionCollection(),
-            new ActionCollection()
+            [],
+            [],
+            []
         );
 
         $collection->add($effect1);
@@ -104,9 +107,9 @@ class EffectCollectionTest extends AbstractUnitTest
             'Effect#1',
             'icon',
             $duration,
-            new ActionCollection(),
-            new ActionCollection(),
-            new ActionCollection()
+            [],
+            [],
+            []
         );
 
         $collection->add($effect);
@@ -152,9 +155,9 @@ class EffectCollectionTest extends AbstractUnitTest
             'Effect#1',
             'icon',
             5,
-            new ActionCollection(),
+            [],
             $actions,
-            new ActionCollection()
+            []
         ));
 
         // 5 раз получаем ActionCollection с HealAction внутри
@@ -189,8 +192,8 @@ class EffectCollectionTest extends AbstractUnitTest
             'Effect#1',
             'icon',
             5,
-            new ActionCollection(),
-            new ActionCollection(),
+            [],
+            [],
             $actions
         ));
 
@@ -204,5 +207,50 @@ class EffectCollectionTest extends AbstractUnitTest
 
         // Затем коллекция эффектов становится пустой - эффект удалился
         self::assertCount(0, $collection);
+    }
+
+    /**
+     * @param UnitInterface $unit
+     * @param CommandInterface $enemyCommand
+     * @param CommandInterface $command
+     * @param int $typeTarget
+     * @return array[]
+     */
+    private function getHealActionData(
+        UnitInterface $unit,
+        CommandInterface $enemyCommand,
+        CommandInterface $command,
+        int $typeTarget
+    ): array
+    {
+        return [
+            [
+                'type'           => ActionInterface::EFFECT,
+                'action_unit'    => $unit,
+                'enemy_command'  => $enemyCommand,
+                'allies_command' => $command,
+                'type_target'    => $typeTarget,
+                'name'           => 'use Reserve Forces',
+                'effect'         => [
+                    'name'                  => 'Effect#123',
+                    'icon'                  => 'icon.png',
+                    'duration'              => 8,
+                    'on_apply_actions'      => [
+                        [
+                            'type'           => ActionInterface::BUFF,
+                            'action_unit'    => $unit,
+                            'enemy_command'  => $enemyCommand,
+                            'allies_command' => $command,
+                            'type_target'    => ActionInterface::TARGET_SELF,
+                            'name'           => 'use Reserve Forces',
+                            'modify_method'  => 'multiplierMaxLife',
+                            'power'          => 130,
+                        ],
+                    ],
+                    'on_next_round_actions' => [],
+                    'on_disable_actions'    => [],
+                ],
+            ]
+        ];
     }
 }

--- a/tests/Battle/Unit/Effect/EffectTest.php
+++ b/tests/Battle/Unit/Effect/EffectTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Tests\Battle\Unit\Effect;
 
 use Battle\Action\ActionCollection;
-use Battle\Action\ActionException;
 use Battle\Action\ActionFactory;
 use Battle\Action\ActionInterface;
+use Battle\Action\DamageAction;
+use Battle\Command\CommandFactory;
 use Battle\Command\CommandInterface;
 use Battle\Unit\Effect\Effect;
 use Battle\Unit\Effect\EffectFactory;
@@ -16,30 +17,28 @@ use Battle\Unit\UnitInterface;
 use Exception;
 use Tests\AbstractUnitTest;
 use Tests\Battle\Factory\BaseFactory;
+use Tests\Battle\Factory\UnitFactory;
 
 class EffectTest extends AbstractUnitTest
 {
     /**
-     * @throws ActionException
+     * @throws Exception
      */
     public function testEffectCreate(): void
     {
         $name = 'Effect Name';
         $icon = 'path_to_icon.png';
         $duration = 10;
-        $onApplyActions = new ActionCollection();
-        $onNextRoundActions = new ActionCollection();
-        $onDisableActions = new ActionCollection();
 
-        $effect = new Effect($name, $icon, $duration, $onApplyActions, $onNextRoundActions, $onDisableActions);
+        $effect = new Effect($name, $icon, $duration, [], [], []);
 
         self::assertEquals($name, $effect->getName());
         self::assertEquals($icon, $effect->getIcon());
         self::assertEquals($duration, $effect->getDuration());
         self::assertEquals($duration, $effect->getBaseDuration());
-        self::assertEquals($onApplyActions, $effect->getOnApplyActions());
-        self::assertEquals($onNextRoundActions, $effect->getOnNextRoundActions());
-        self::assertEquals($onDisableActions, $effect->getOnDisableActions());
+        self::assertEquals(new ActionCollection(), $effect->getOnApplyActions());
+        self::assertEquals(new ActionCollection(), $effect->getOnNextRoundActions());
+        self::assertEquals(new ActionCollection(), $effect->getOnDisableActions());
 
         $effect->nextRound();
         $effect->nextRound();
@@ -85,6 +84,41 @@ class EffectTest extends AbstractUnitTest
 
         foreach ($effect->getOnDisableActions() as $action) {
             self::assertEquals($enemyUnit, $action->getActionUnit());
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testEffectChangeMultipleActionUnit(): void
+    {
+        $unit = UnitFactory::createByTemplate(1);
+        $enemyUnit = UnitFactory::createByTemplate(2);
+        $secondaryEnemyUnit = UnitFactory::createByTemplate(3);
+        $command = CommandFactory::create([$unit]);
+        $enemyCommand = CommandFactory::create([$enemyUnit, $secondaryEnemyUnit]);
+
+        $action = $this->createIncinerationAction($unit, $enemyCommand, $command);
+
+        // До применения эффекта на противника Action которые будут применяться от эффекта имеют ActionUnit создателя
+        foreach ($action->getEffect()->getOnNextRoundActions() as $nextRoundAction) {
+            self::assertEquals($unit, $nextRoundAction->getActionUnit());
+        }
+
+        self::assertTrue($action->canByUsed());
+        $action->handle();
+
+        // После применения эффекта все Action от эффектов привязаны к своим родительским юнитам
+        foreach ($enemyUnit->getEffects() as $effect) {
+            foreach ($effect->getOnNextRoundActions() as $nextRoundAction) {
+                self::assertEquals($enemyUnit->getId(), $nextRoundAction->getActionUnit()->getId());
+            }
+        }
+
+        foreach ($secondaryEnemyUnit->getEffects() as $effect) {
+            foreach ($effect->getOnNextRoundActions() as $nextRoundAction) {
+                self::assertEquals($secondaryEnemyUnit->getId(), $nextRoundAction->getActionUnit()->getId());
+            }
         }
     }
 
@@ -135,5 +169,53 @@ class EffectTest extends AbstractUnitTest
         ];
 
         return $factory->create($data);
+    }
+
+    /**
+     * @param UnitInterface $actionUnit
+     * @param CommandInterface $enemyCommand
+     * @param CommandInterface $command
+     * @return ActionInterface
+     * @throws Exception
+     */
+    private function createIncinerationAction(
+        UnitInterface $actionUnit,
+        CommandInterface $enemyCommand,
+        CommandInterface $command
+    ): ActionInterface
+    {
+        $data = [
+            'type'           => ActionInterface::EFFECT,
+            'action_unit'    => $actionUnit,
+            'enemy_command'  => $enemyCommand,
+            'allies_command' => $command,
+            'type_target'    => ActionInterface::TARGET_ALL_ENEMY,
+            'name'           => 'Incineration',
+            'icon'           => '/images/icons/ability/232.png',
+            'message_method' => 'applyEffect',
+            'effect'         => [
+                'name'                  => 'Incineration',
+                'icon'                  => '/images/icons/ability/232.png',
+                'duration'              => 8,
+                'on_apply_actions'      => [],
+                'on_next_round_actions' => [
+                    [
+                        'type'             => ActionInterface::DAMAGE,
+                        'action_unit'      => $actionUnit,
+                        'enemy_command'    => $enemyCommand,
+                        'allies_command'   => $command,
+                        'type_target'      => ActionInterface::TARGET_SELF,
+                        'name'             => 'Incineration',
+                        'power'            => 6,
+                        'animation_method' => DamageAction::EFFECT_ANIMATION_METHOD,
+                        'message_method'   => DamageAction::EFFECT_MESSAGE_METHOD,
+                        'icon'             => '/images/icons/ability/232.png',
+                    ],
+                ],
+                'on_disable_actions'    => [],
+            ],
+        ];
+
+        return (new ActionFactory())->create($data);
     }
 }


### PR DESCRIPTION
Второй вариант исправления ошибки при применении эффекта на несколько целей одновременно.

В этом варианте эффект на каждый запрос:
getOnApplyActions()
getOnNextRoundActions()
getOnDisableActions()

Каждый раз создает ActionCollection с нуля. Но вариант оказался таким же нерабочим и еще более кривым, чем в ветке MA-1

Ветка создается на всякий случай, чтобы была возможность вернуться к наработкам.